### PR TITLE
pathinfo模式下请求参数的值中携带的"/"符号被当作分割符，造成以下URL识别报错：/admin?nsukey=LArYyDnVsr…

### DIFF
--- a/yzmphp/core/class/param.class.php
+++ b/yzmphp/core/class/param.class.php
@@ -84,7 +84,8 @@ class param {
 		if (isset($_SERVER['PATH_INFO']) && !empty($_SERVER['PATH_INFO'])){
 			$_SERVER['PATH_INFO'] = str_ireplace(array(C('url_html_suffix'), 'index.php'), '', $_SERVER['PATH_INFO']);
 			if(C('route_mapping')) $this->mapping(set_mapping($this->route_config['m']));
-			$pathinfo = explode('/', trim($_SERVER['PATH_INFO'], '/'));		
+			$no_query_params = strstr($_SERVER['PATH_INFO'], '?', true);
+			$pathinfo = explode('/', trim($no_query_params ? $no_query_params : $_SERVER['PATH_INFO'], '/'));		
 			$_GET['m'] = isset($pathinfo[0]) ? $pathinfo[0] : '';
 			$_GET['c'] = isset($pathinfo[1]) ? $pathinfo[1] : '';
 			$_GET['a'] = isset($pathinfo[2]) ? $pathinfo[2] : '';


### PR DESCRIPTION
pathinfo模式下请求参数的值中携带的"/"符号被当作分割符，造成以下URL识别报错：`/admin?nsukey=LArYyDnVsrPf7%2Fnp4NELCWIr78w3Q%2B3NAh%2FjTWFY1ZP%2FBeEc6np6TN297%2Fo%2FPHpUsEdooy14YJ5AVbl%2F3EbgbHLysJYV9I5Oy6FIJnuWDlRM1K28A4EGwUZIRJNCNSgTMHytJquECXoEP55zHjHVN4pKd0AT6Cz8Q67Ten3fqSOjgdxVR6hPA8zPLVXcqXFTR8whvh7tE3qcX2EbClE5jQ%3D%3D`